### PR TITLE
Add missing resume command to help output

### DIFF
--- a/btsync-user/scripts/btsync
+++ b/btsync-user/scripts/btsync
@@ -39,7 +39,7 @@ Commands:
  stop               stop the btsync system
  restart            restarts the btsync system
  pause              suspends the btsync system
- stop               resumes the btsync system
+ resume             resumes the btsync system
  status             output the btsync status
  debug|setdebug	    enables/configures/disables verbose logging
  nodebug            disables verbose logging


### PR DESCRIPTION
"stop" is listed twice.  The command that the script expects is "resume."
