### PR TITLE
btsync-common: Updated to upstream version to 1.3.77

### DIFF
--- a/btsync-common/debian/changelog
+++ b/btsync-common/debian/changelog
@@ -1,3 +1,9 @@
+btsync-common (1.3.77-1) unstable; urgency=low
+
+  * New upstream release
+
+ -- Leo Moll <leo.moll@yeasoft.com>  Tue, 01 Apr 2014 09:24:00 +0100
+
 btsync-common (1.3.67-1) unstable; urgency=low
 
   * New upstream release

--- a/btsync-common/debian/history/changelog
+++ b/btsync-common/debian/history/changelog
@@ -1,3 +1,10 @@
+1.3.77 (March 31, 2014)
+
+ - Fixed crashes on all platforms
+ - Fixed issue with clients discovery in LAN
+ - Fixed issue with redundant .conflict files and folders creation
+
+
 1.3.67 (March 21, 2014)
 
  - Added log rotation value in Advanced preferences 


### PR DESCRIPTION
Bump to upstream 1.3.77. Keeping signing key as your email in changelog.
