### PR TITLE
btsync-gui: Changed "synched" to "synced" to keep consistency

### DIFF
--- a/btsync-gui/btsyncapp.glade
+++ b/btsync-gui/btsyncapp.glade
@@ -87,7 +87,7 @@
         <property name="use_action_appearance">False</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="tooltip_text" translatable="yes">Edit the file containing the list or filename patterns for file not being synched</property>
+        <property name="tooltip_text" translatable="yes">Edit the file containing the list or filename patterns for file not being synced</property>
         <property name="label" translatable="yes">Edit .SyncIgnore</property>
         <property name="use_underline">True</property>
         <signal name="activate" handler="onFoldersEditSyncIgnore" swapped="no"/>

--- a/btsync-gui/btsyncapp.py
+++ b/btsync-gui/btsyncapp.py
@@ -345,7 +345,7 @@ class BtSyncApp(BtInputHelper,BtMessageHelper):
 	def get_device_info_string(self,peer):
 		if peer['synced'] != 0:
 			dt = datetime.datetime.fromtimestamp(peer['synced'])
-			return _('Synched on {0}').format(dt.strftime("%x %X"))
+			return _('Synced on {0}').format(dt.strftime("%x %X"))
 		elif peer['download'] == 0 and peer['upload'] != 0:
 			return _('⇧ {0}').format(self.sizeof_fmt(peer['upload']))
 		elif peer['download'] != 0 and peer['upload'] == 0:

--- a/btsync-gui/po/bg.po
+++ b/btsync-gui/po/bg.po
@@ -40,7 +40,7 @@ msgid "{0} in {1} files (indexing...)"
 msgstr "{0} в {1} файла (индексиране...)"
 
 #: ../btsyncapp.py:348
-msgid "Synched on {0}"
+msgid "Synced on {0}"
 msgstr "Синхронизирано {0}"
 
 #: ../btsyncapp.py:350
@@ -226,7 +226,7 @@ msgid "Edit .SyncIgnore"
 msgstr "Редактирай .SyncIgnore"
 
 #: ../btsyncapp.glade.h:13
-msgid "Edit the file containing the list or filename patterns for file not being synched"
+msgid "Edit the file containing the list or filename patterns for file not being synced"
 msgstr "Редактиране на файла, съдържащ списък с имената или шаблоните на файловете, който не трябва да бъдат синхронизирани"
 
 #: ../btsyncapp.glade.h:14

--- a/btsync-gui/po/cs.po
+++ b/btsync-gui/po/cs.po
@@ -40,7 +40,7 @@ msgid "{0} in {1} files (indexing...)"
 msgstr "{0} v {1} souborech (indexuji...)"
 
 #: ../btsyncapp.py:348
-msgid "Synched on {0}"
+msgid "Synced on {0}"
 msgstr "Synchronizováno {0}"
 
 #: ../btsyncapp.py:350
@@ -226,7 +226,7 @@ msgid "Edit .SyncIgnore"
 msgstr "Upravit .SyncIgnore"
 
 #: ../btsyncapp.glade.h:13
-msgid "Edit the file containing the list or filename patterns for file not being synched"
+msgid "Edit the file containing the list or filename patterns for file not being synced"
 msgstr "Upravit soubor obsahující seznam pravidel pro soubory, které nejsou synchronizovány"
 
 #: ../btsyncapp.glade.h:14

--- a/btsync-gui/po/de.po
+++ b/btsync-gui/po/de.po
@@ -40,7 +40,7 @@ msgid "{0} in {1} files (indexing...)"
 msgstr "{0} in {1} Datei(en) (indiziert...)"
 
 #: ../btsyncapp.py:348
-msgid "Synched on {0}"
+msgid "Synced on {0}"
 msgstr "Synchronisiert am {0}"
 
 #: ../btsyncapp.py:350
@@ -226,7 +226,7 @@ msgid "Edit .SyncIgnore"
 msgstr ".SyncIgnore Datei editieren"
 
 #: ../btsyncapp.glade.h:13
-msgid "Edit the file containing the list or filename patterns for file not being synched"
+msgid "Edit the file containing the list or filename patterns for file not being synced"
 msgstr "Liste der Dateienamen und Namensmuster die von der Synchronisation ausgeschlossen werden sollen editieren"
 
 #: ../btsyncapp.glade.h:14

--- a/btsync-gui/po/es.po
+++ b/btsync-gui/po/es.po
@@ -40,7 +40,7 @@ msgid "{0} in {1} files (indexing...)"
 msgstr "{0} en {1} archivos (indexando...)"
 
 #: ../btsyncapp.py:348
-msgid "Synched on {0}"
+msgid "Synced on {0}"
 msgstr "Sincronizado en {0}"
 
 #: ../btsyncapp.py:350
@@ -226,7 +226,7 @@ msgid "Edit .SyncIgnore"
 msgstr "Editar .SyncIgnore"
 
 #: ../btsyncapp.glade.h:13
-msgid "Edit the file containing the list or filename patterns for file not being synched"
+msgid "Edit the file containing the list or filename patterns for file not being synced"
 msgstr "Editar el archivo que contiene la lista o patrones de nombres de archivo para los archivos que no deben ser sincronizados"
 
 #: ../btsyncapp.glade.h:14

--- a/btsync-gui/po/fr.po
+++ b/btsync-gui/po/fr.po
@@ -40,7 +40,7 @@ msgid "{0} in {1} files (indexing...)"
 msgstr "{0} dans {1} fichiers (indexation...)"
 
 #: ../btsyncapp.py:348
-msgid "Synched on {0}"
+msgid "Synced on {0}"
 msgstr "Synchronisé le {0}"
 
 #: ../btsyncapp.py:350
@@ -231,7 +231,7 @@ msgid "Edit .SyncIgnore"
 msgstr "Éditer .SyncIgnore"
 
 #: ../btsyncapp.glade.h:13
-msgid "Edit the file containing the list or filename patterns for file not being synched"
+msgid "Edit the file containing the list or filename patterns for file not being synced"
 msgstr "Éditer le fichier contentant la liste ou les modèles de noms de fichiers pour les fichiers qui ne sont pas synchronisés"
 
 #: ../btsyncapp.glade.h:14

--- a/btsync-gui/po/gl.po
+++ b/btsync-gui/po/gl.po
@@ -40,7 +40,7 @@ msgid "{0} in {1} files (indexing...)"
 msgstr "{0} en {1} ficheiros (indexando...)"
 
 #: ../btsyncapp.py:348
-msgid "Synched on {0}"
+msgid "Synced on {0}"
 msgstr "Sincronizado en {0}"
 
 #: ../btsyncapp.py:350
@@ -226,7 +226,7 @@ msgid "Edit .SyncIgnore"
 msgstr "Editar .SyncIgnore"
 
 #: ../btsyncapp.glade.h:13
-msgid "Edit the file containing the list or filename patterns for file not being synched"
+msgid "Edit the file containing the list or filename patterns for file not being synced"
 msgstr "Editar o ficheiro que conten a lista patróns de nomes de ficheiro dos ficheiros que non foron sincronizados"
 
 #: ../btsyncapp.glade.h:14

--- a/btsync-gui/po/it.po
+++ b/btsync-gui/po/it.po
@@ -40,7 +40,7 @@ msgid "{0} in {1} files (indexing...)"
 msgstr "{0} in {1} files (indicizzando...)"
 
 #: ../btsyncapp.py:348
-msgid "Synched on {0}"
+msgid "Synced on {0}"
 msgstr "Sincronizzato il {0}"
 
 #: ../btsyncapp.py:350
@@ -226,7 +226,7 @@ msgid "Edit .SyncIgnore"
 msgstr "Modifica .SyncIgnore"
 
 #: ../btsyncapp.glade.h:13
-msgid "Edit the file containing the list or filename patterns for file not being synched"
+msgid "Edit the file containing the list or filename patterns for file not being synced"
 msgstr "Modifica il contenuto della lista dei file e delle estensioni non sincronizzate"
 
 #: ../btsyncapp.glade.h:14

--- a/btsync-gui/po/nl.po
+++ b/btsync-gui/po/nl.po
@@ -40,7 +40,7 @@ msgid "{0} in {1} files (indexing...)"
 msgstr "{0} in {1} files (indexeren...)"
 
 #: ../btsyncapp.py:348
-msgid "Synched on {0}"
+msgid "Synced on {0}"
 msgstr "Gesynchroniseerd op {0}"
 
 #: ../btsyncapp.py:350
@@ -225,7 +225,7 @@ msgid "Edit .SyncIgnore"
 msgstr "Wijzig .SyncIgnore"
 
 #: ../btsyncapp.glade.h:13
-msgid "Edit the file containing the list or filename patterns for file not being synched"
+msgid "Edit the file containing the list or filename patterns for file not being synced"
 msgstr "Wijzig het bestand met de lijst van bestandsnaam-patronen welke niet gesynchroniseerd zullen worden"
 
 #: ../btsyncapp.glade.h:14

--- a/btsync-gui/po/pl.po
+++ b/btsync-gui/po/pl.po
@@ -40,7 +40,7 @@ msgid "{0} in {1} files (indexing...)"
 msgstr "{0} z {1} plików (indeksowanie...)"
 
 #: ../btsyncapp.py:348
-msgid "Synched on {0}"
+msgid "Synced on {0}"
 msgstr "Zsynchronizowano {0}"
 
 #: ../btsyncapp.py:350
@@ -227,7 +227,7 @@ msgid "Edit .SyncIgnore"
 msgstr "Edytuj .SyncIgnore"
 
 #: ../btsyncapp.glade.h:13
-msgid "Edit the file containing the list or filename patterns for file not being synched"
+msgid "Edit the file containing the list or filename patterns for file not being synced"
 msgstr "Edytuj plik zawierający listę lub nazwę wzorca dla plików, które nie będę synchronizowane"
 
 #: ../btsyncapp.glade.h:14

--- a/btsync-gui/po/ru.po
+++ b/btsync-gui/po/ru.po
@@ -40,7 +40,7 @@ msgid "{0} in {1} files (indexing...)"
 msgstr "{0} в {1} файлах (индексация...)"
 
 #: ../btsyncapp.py:348
-msgid "Synched on {0}"
+msgid "Synced on {0}"
 msgstr "Синхронизировано {0}"
 
 #: ../btsyncapp.py:350
@@ -227,7 +227,7 @@ msgid "Edit .SyncIgnore"
 msgstr "Редактировать список исключений"
 
 #: ../btsyncapp.glade.h:13
-msgid "Edit the file containing the list or filename patterns for file not being synched"
+msgid "Edit the file containing the list or filename patterns for file not being synced"
 msgstr "Редактировать файл .SyncIgnore со списком имен и шаблонами файлов, которые не должны синхронизироваться"
 
 #: ../btsyncapp.glade.h:14

--- a/btsync-gui/po/templates.pot
+++ b/btsync-gui/po/templates.pot
@@ -52,7 +52,7 @@ msgid "{0} in {1} files (indexing...)"
 msgstr ""
 
 #: ../btsyncapp.py:348
-msgid "Synched on {0}"
+msgid "Synced on {0}"
 msgstr ""
 
 #: ../btsyncapp.py:350
@@ -288,7 +288,7 @@ msgstr ""
 #: ../btsyncapp.glade.h:13
 msgid ""
 "Edit the file containing the list or filename patterns for file not being "
-"synched"
+"synced"
 msgstr ""
 
 #: ../btsyncapp.glade.h:14


### PR DESCRIPTION
This terminology is consistent with the "official" BitTorrent Sync GUI clients for Windows and OS X.
