### PR TITLE
feature/uisettings

### DIFF
--- a/btsync-gui/btsyncagent.py
+++ b/btsync-gui/btsyncagent.py
@@ -60,24 +60,9 @@ class BtSyncAgent(BtSyncApi):
 		self.preffile = self.configpath + '/btsync-gui.prefs'
 		self.lockfile = self.configpath + '/btsync-gui.pid'
 		self.lock = None
-		self.prefs = {}
-		# load values from preferences
+		# load values from preferences file
 		self.load_prefs()
-		# generate random credentials
-		try:
-			username = base64.b64encode(os.urandom(16))[:-2]
-			password = base64.b64encode(os.urandom(32))[:-2]
-		except NotImplementedError:
-			logging.warning('No good random generator available. Using default credentials')
-			username = 'btsync-ui'
-			password = base64.b64encode('This is really not secure!')[:-2]
-		self.username = self.get_pref('username',username)
-		self.password = self.get_pref('password',password)
-		self.bindui = self.get_pref('bindui','127.0.0.1')
-		self.portui = self.get_pref('portui',self.uid + 8999)
-		self.paused = self.get_pref('paused',False)
-		self.webui = self.get_pref('webui',False)
-		self.dark = self.get_pref('dark',False)
+		self.read_prefs()
 		# process command line arguments
 		if self.args.username is not None:
 			self.username = self.args.username
@@ -229,6 +214,25 @@ class BtSyncAgent(BtSyncApi):
 		except Exception as e:
 			logging.warning('Error while loading preferences: {0}'.format(e))
 			self.prefs = {}
+
+	def read_prefs(self):
+		# generate random credentials
+		try:
+			username = base64.b64encode(os.urandom(16))[:-2]
+			password = base64.b64encode(os.urandom(32))[:-2]
+		except NotImplementedError:
+			logging.warning('No good random generator available. Using default credentials')
+			username = 'btsync-ui'
+			password = base64.b64encode('This is really not secure!')[:-2]
+		# read in application preferences
+		self.username = self.get_pref('username',username)
+		self.password = self.get_pref('password',password)
+		self.bindui = self.get_pref('bindui','127.0.0.1')
+		self.portui = self.get_pref('portui',self.uid + 8999)
+		self.paused = self.get_pref('paused',False)
+		self.webui = self.get_pref('webui',False)
+		self.dark = self.get_pref('dark',False)
+		self.foldersmenu = self.get_pref('foldersMenu',False)
 
 	def make_local_paths(self):
 		if not os.path.isdir(self.configpath):

--- a/btsync-gui/btsyncapp.glade
+++ b/btsync-gui/btsyncapp.glade
@@ -832,8 +832,8 @@
               </object>
               <packing>
                 <property name="left_attach">1</property>
-                <property name="top_attach">2</property>
-                <property name="width">1</property>
+                <property name="top_attach">4</property>
+                <property name="width">2</property>
                 <property name="height">1</property>
               </packing>
             </child>
@@ -849,7 +849,7 @@
               </object>
               <packing>
                 <property name="left_attach">1</property>
-                <property name="top_attach">0</property>
+                <property name="top_attach">2</property>
                 <property name="width">2</property>
                 <property name="height">1</property>
               </packing>
@@ -866,14 +866,14 @@
               </object>
               <packing>
                 <property name="left_attach">1</property>
-                <property name="top_attach">1</property>
+                <property name="top_attach">3</property>
                 <property name="width">2</property>
                 <property name="height">1</property>
               </packing>
             </child>
             <child>
               <object class="GtkButton" id="buttonAdvanced">
-                <property name="label" translatable="yes">Advanced</property>
+                <property name="label" translatable="yes">Advanced Connection Settings</property>
                 <property name="use_action_appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
@@ -881,11 +881,40 @@
                 <signal name="clicked" handler="onSettingsClickedAdvanced" swapped="no"/>
               </object>
               <packing>
-                <property name="left_attach">2</property>
-                <property name="top_attach">2</property>
-                <property name="width">1</property>
+                <property name="left_attach">1</property>
+                <property name="top_attach">5</property>
+                <property name="width">2</property>
                 <property name="height">1</property>
               </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="label1">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">This page contains local settings that affect only the function of the BitTorrent Sync GUI. The settings are stored locally in the user's home directory.</property>
+                <property name="wrap">True</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">0</property>
+                <property name="width">3</property>
+                <property name="height">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkSeparator" id="separator1">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">1</property>
+                <property name="width">3</property>
+                <property name="height">1</property>
+              </packing>
+            </child>
+            <child>
+              <placeholder/>
             </child>
             <child>
               <placeholder/>

--- a/btsync-gui/btsyncapp.glade
+++ b/btsync-gui/btsyncapp.glade
@@ -1,6 +1,135 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.16.1 -->
 <interface>
-  <!-- interface-requires gtk+ 3.0 -->
+  <requires lib="gtk+" version="3.0"/>
+  <object class="GtkListStore" id="devices_list">
+    <columns>
+      <!-- column-name Device -->
+      <column type="gchararray"/>
+      <!-- column-name Folder -->
+      <column type="gchararray"/>
+      <!-- column-name Status -->
+      <column type="gchararray"/>
+      <!-- column-name Secret -->
+      <column type="gchararray"/>
+      <!-- column-name FolderTag -->
+      <column type="gchararray"/>
+      <!-- column-name DeviceTag -->
+      <column type="gchararray"/>
+      <!-- column-name ConnectionIconName -->
+      <column type="gchararray"/>
+      <!-- column-name EllipsizeMode -->
+      <column type="gint"/>
+    </columns>
+  </object>
+  <object class="GtkListStore" id="folders_list">
+    <columns>
+      <!-- column-name Folder -->
+      <column type="gchararray"/>
+      <!-- column-name Content -->
+      <column type="gchararray"/>
+      <!-- column-name Secret -->
+      <column type="gchararray"/>
+      <!-- column-name FolderTag -->
+      <column type="gchararray"/>
+      <!-- column-name EllipsizeMode -->
+      <column type="gint"/>
+    </columns>
+  </object>
+  <object class="GtkMenu" id="folders_menu">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <child>
+      <object class="GtkMenuItem" id="folder_menu_copy">
+        <property name="use_action_appearance">False</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="tooltip_text" translatable="yes">Copies the sharing secret to the clipboard</property>
+        <property name="label" translatable="yes">Copy secret</property>
+        <property name="use_underline">True</property>
+        <signal name="activate" handler="onFoldersCopySecret" swapped="no"/>
+      </object>
+    </child>
+    <child>
+      <object class="GtkMenuItem" id="folder_menu_connect">
+        <property name="use_action_appearance">False</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="tooltip_text" translatable="yes">Displays a QR-code that permits easy connection of a mobile device to this folder</property>
+        <property name="label" translatable="yes">Connect mobile device</property>
+        <property name="use_underline">True</property>
+        <signal name="activate" handler="onFoldersConnectMobile" swapped="no"/>
+      </object>
+    </child>
+    <child>
+      <object class="GtkMenuItem" id="folder_menu_openfolder">
+        <property name="use_action_appearance">False</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="tooltip_text" translatable="yes">Opens the folder in the file manager</property>
+        <property name="label" translatable="yes">Open Folder</property>
+        <property name="use_underline">True</property>
+        <signal name="activate" handler="onFoldersOpenFolder" swapped="no"/>
+      </object>
+    </child>
+    <child>
+      <object class="GtkMenuItem" id="folder_menu_openarchive">
+        <property name="use_action_appearance">False</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="tooltip_text" translatable="yes">Opens the sync archive holding previous or deleted versions of files</property>
+        <property name="label" translatable="yes">Open SyncArchive</property>
+        <property name="use_underline">True</property>
+        <signal name="activate" handler="onFoldersOpenArchive" swapped="no"/>
+      </object>
+    </child>
+    <child>
+      <object class="GtkMenuItem" id="folder_menu_editsyncignore">
+        <property name="use_action_appearance">False</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="tooltip_text" translatable="yes">Edit the file containing the list or filename patterns for file not being synced</property>
+        <property name="label" translatable="yes">Edit .SyncIgnore</property>
+        <property name="use_underline">True</property>
+        <signal name="activate" handler="onFoldersEditSyncIgnore" swapped="no"/>
+      </object>
+    </child>
+    <child>
+      <object class="GtkMenuItem" id="folder_menu_prefs">
+        <property name="use_action_appearance">False</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="tooltip_text" translatable="yes">Opens the preferences dialog for the shared folder</property>
+        <property name="label" translatable="yes">Show folder preferences</property>
+        <property name="use_underline">True</property>
+        <signal name="activate" handler="onFoldersPreferences" swapped="no"/>
+      </object>
+    </child>
+  </object>
+  <object class="GtkListStore" id="history_list">
+    <columns>
+      <!-- column-name Date -->
+      <column type="gchararray"/>
+      <!-- column-name Event -->
+      <column type="gchararray"/>
+      <!-- column-name EllipsizeMode -->
+      <column type="gint"/>
+    </columns>
+  </object>
+  <object class="GtkListStore" id="transfers_list">
+    <columns>
+      <!-- column-name File -->
+      <column type="gchararray"/>
+      <!-- column-name Device -->
+      <column type="gchararray"/>
+      <!-- column-name Up -->
+      <column type="gchararray"/>
+      <!-- column-name Down -->
+      <column type="gchararray"/>
+      <!-- column-name EllipsizeMode -->
+      <column type="gint"/>
+    </columns>
+  </object>
   <object class="GtkWindow" id="btsyncapp">
     <property name="can_focus">False</property>
     <property name="border_width">12</property>
@@ -89,7 +218,6 @@
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                    <property name="use_action_appearance">False</property>
                     <property name="use_stock">True</property>
                     <signal name="clicked" handler="onFoldersAdd" swapped="no"/>
                   </object>
@@ -106,7 +234,6 @@
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                    <property name="use_action_appearance">False</property>
                     <property name="use_stock">True</property>
                     <signal name="clicked" handler="onFoldersRemove" swapped="no"/>
                   </object>
@@ -482,7 +609,6 @@
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_action_appearance">False</property>
                 <property name="xalign">0</property>
                 <property name="draw_indicator">True</property>
               </object>
@@ -514,7 +640,6 @@
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_action_appearance">False</property>
                 <property name="xalign">0</property>
                 <property name="draw_indicator">True</property>
               </object>
@@ -532,7 +657,6 @@
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_action_appearance">False</property>
                 <property name="xalign">0</property>
                 <property name="draw_indicator">True</property>
                 <signal name="toggled" handler="onPreferencesToggledLimitDn" swapped="no"/>
@@ -550,7 +674,6 @@
                 <property name="sensitive">False</property>
                 <property name="can_focus">True</property>
                 <property name="invisible_char">●</property>
-                <property name="invisible_char_set">True</property>
               </object>
               <packing>
                 <property name="left_attach">2</property>
@@ -566,7 +689,6 @@
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_action_appearance">False</property>
                 <property name="xalign">0</property>
                 <property name="draw_indicator">True</property>
                 <signal name="toggled" handler="onPreferencesToggledLimitUp" swapped="no"/>
@@ -584,7 +706,6 @@
                 <property name="sensitive">False</property>
                 <property name="can_focus">True</property>
                 <property name="invisible_char">●</property>
-                <property name="invisible_char_set">True</property>
               </object>
               <packing>
                 <property name="left_attach">2</property>
@@ -615,7 +736,6 @@
                 <property name="can_focus">True</property>
                 <property name="invisible_char">●</property>
                 <property name="shadow_type">etched-out</property>
-                <property name="invisible_char_set">True</property>
               </object>
               <packing>
                 <property name="left_attach">1</property>
@@ -631,7 +751,6 @@
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_action_appearance">False</property>
                 <signal name="clicked" handler="onPreferencesClickedAdvanced" swapped="no"/>
               </object>
               <packing>
@@ -646,7 +765,6 @@
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="invisible_char">●</property>
-                <property name="invisible_char_set">True</property>
               </object>
               <packing>
                 <property name="left_attach">1</property>
@@ -709,7 +827,6 @@
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_action_appearance">False</property>
                 <property name="xalign">0</property>
                 <property name="draw_indicator">True</property>
               </object>
@@ -727,8 +844,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_action_appearance">False</property>
-                <property name="xalign">0</property>
+                <property name="xalign">0.090000003576278687</property>
                 <property name="draw_indicator">True</property>
               </object>
               <packing>
@@ -739,13 +855,12 @@
               </packing>
             </child>
             <child>
-              <object class="GtkCheckButton" id="enableFolderMenu">
+              <object class="GtkCheckButton" id="enableFoldersMenu">
                 <property name="label" translatable="yes">Enable Folder Display in Menu</property>
                 <property name="use_action_appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_action_appearance">False</property>
                 <property name="xalign">0</property>
                 <property name="draw_indicator">True</property>
               </object>
@@ -757,49 +872,13 @@
               </packing>
             </child>
             <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
               <object class="GtkButton" id="buttonAdvanced">
                 <property name="label" translatable="yes">Advanced</property>
                 <property name="use_action_appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_action_appearance">False</property>
+                <signal name="clicked" handler="onSettingsClickedAdvanced" swapped="no"/>
               </object>
               <packing>
                 <property name="left_attach">2</property>
@@ -807,6 +886,15 @@
                 <property name="width">1</property>
                 <property name="height">1</property>
               </packing>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
             </child>
           </object>
           <packing>
@@ -826,133 +914,5 @@
         </child>
       </object>
     </child>
-  </object>
-  <object class="GtkListStore" id="devices_list">
-    <columns>
-      <!-- column-name Device -->
-      <column type="gchararray"/>
-      <!-- column-name Folder -->
-      <column type="gchararray"/>
-      <!-- column-name Status -->
-      <column type="gchararray"/>
-      <!-- column-name Secret -->
-      <column type="gchararray"/>
-      <!-- column-name FolderTag -->
-      <column type="gchararray"/>
-      <!-- column-name DeviceTag -->
-      <column type="gchararray"/>
-      <!-- column-name ConnectionIconName -->
-      <column type="gchararray"/>
-      <!-- column-name EllipsizeMode -->
-      <column type="gint"/>
-    </columns>
-  </object>
-  <object class="GtkListStore" id="folders_list">
-    <columns>
-      <!-- column-name Folder -->
-      <column type="gchararray"/>
-      <!-- column-name Content -->
-      <column type="gchararray"/>
-      <!-- column-name Secret -->
-      <column type="gchararray"/>
-      <!-- column-name FolderTag -->
-      <column type="gchararray"/>
-      <!-- column-name EllipsizeMode -->
-      <column type="gint"/>
-    </columns>
-  </object>
-  <object class="GtkMenu" id="folders_menu">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <child>
-      <object class="GtkMenuItem" id="folder_menu_copy">
-        <property name="use_action_appearance">False</property>
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="tooltip_text" translatable="yes">Copies the sharing secret to the clipboard</property>
-        <property name="label" translatable="yes">Copy secret</property>
-        <property name="use_underline">True</property>
-        <signal name="activate" handler="onFoldersCopySecret" swapped="no"/>
-      </object>
-    </child>
-    <child>
-      <object class="GtkMenuItem" id="folder_menu_connect">
-        <property name="use_action_appearance">False</property>
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="tooltip_text" translatable="yes">Displays a QR-code that permits easy connection of a mobile device to this folder</property>
-        <property name="label" translatable="yes">Connect mobile device</property>
-        <property name="use_underline">True</property>
-        <signal name="activate" handler="onFoldersConnectMobile" swapped="no"/>
-      </object>
-    </child>
-    <child>
-      <object class="GtkMenuItem" id="folder_menu_openfolder">
-        <property name="use_action_appearance">False</property>
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="tooltip_text" translatable="yes">Opens the folder in the file manager</property>
-        <property name="label" translatable="yes">Open Folder</property>
-        <property name="use_underline">True</property>
-        <signal name="activate" handler="onFoldersOpenFolder" swapped="no"/>
-      </object>
-    </child>
-    <child>
-      <object class="GtkMenuItem" id="folder_menu_openarchive">
-        <property name="use_action_appearance">False</property>
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="tooltip_text" translatable="yes">Opens the sync archive holding previous or deleted versions of files</property>
-        <property name="label" translatable="yes">Open SyncArchive</property>
-        <property name="use_underline">True</property>
-        <signal name="activate" handler="onFoldersOpenArchive" swapped="no"/>
-      </object>
-    </child>
-    <child>
-      <object class="GtkMenuItem" id="folder_menu_editsyncignore">
-        <property name="use_action_appearance">False</property>
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="tooltip_text" translatable="yes">Edit the file containing the list or filename patterns for file not being synced</property>
-        <property name="label" translatable="yes">Edit .SyncIgnore</property>
-        <property name="use_underline">True</property>
-        <signal name="activate" handler="onFoldersEditSyncIgnore" swapped="no"/>
-      </object>
-    </child>
-    <child>
-      <object class="GtkMenuItem" id="folder_menu_prefs">
-        <property name="use_action_appearance">False</property>
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="tooltip_text" translatable="yes">Opens the preferences dialog for the shared folder</property>
-        <property name="label" translatable="yes">Show folder preferences</property>
-        <property name="use_underline">True</property>
-        <signal name="activate" handler="onFoldersPreferences" swapped="no"/>
-      </object>
-    </child>
-  </object>
-  <object class="GtkListStore" id="history_list">
-    <columns>
-      <!-- column-name Date -->
-      <column type="gchararray"/>
-      <!-- column-name Event -->
-      <column type="gchararray"/>
-      <!-- column-name EllipsizeMode -->
-      <column type="gint"/>
-    </columns>
-  </object>
-  <object class="GtkListStore" id="transfers_list">
-    <columns>
-      <!-- column-name File -->
-      <column type="gchararray"/>
-      <!-- column-name Device -->
-      <column type="gchararray"/>
-      <!-- column-name Up -->
-      <column type="gchararray"/>
-      <!-- column-name Down -->
-      <column type="gchararray"/>
-      <!-- column-name EllipsizeMode -->
-      <column type="gint"/>
-    </columns>
   </object>
 </interface>

--- a/btsync-gui/btsyncapp.glade
+++ b/btsync-gui/btsyncapp.glade
@@ -844,7 +844,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">False</property>
-                <property name="xalign">0.090000003576278687</property>
+                <property name="xalign">0</property>
                 <property name="draw_indicator">True</property>
               </object>
               <packing>

--- a/btsync-gui/btsyncapp.glade
+++ b/btsync-gui/btsyncapp.glade
@@ -1,120 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <!-- interface-requires gtk+ 3.0 -->
-  <object class="GtkListStore" id="devices_list">
-    <columns>
-      <!-- column-name Device -->
-      <column type="gchararray"/>
-      <!-- column-name Folder -->
-      <column type="gchararray"/>
-      <!-- column-name Status -->
-      <column type="gchararray"/>
-      <!-- column-name Secret -->
-      <column type="gchararray"/>
-      <!-- column-name FolderTag -->
-      <column type="gchararray"/>
-      <!-- column-name DeviceTag -->
-      <column type="gchararray"/>
-      <!-- column-name ConnectionIconName -->
-      <column type="gchararray"/>
-      <!-- column-name EllipsizeMode -->
-      <column type="gint"/>
-    </columns>
-  </object>
-  <object class="GtkListStore" id="folders_list">
-    <columns>
-      <!-- column-name Folder -->
-      <column type="gchararray"/>
-      <!-- column-name Content -->
-      <column type="gchararray"/>
-      <!-- column-name Secret -->
-      <column type="gchararray"/>
-      <!-- column-name FolderTag -->
-      <column type="gchararray"/>
-      <!-- column-name EllipsizeMode -->
-      <column type="gint"/>
-    </columns>
-  </object>
-  <object class="GtkMenu" id="folders_menu">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <child>
-      <object class="GtkMenuItem" id="folder_menu_copy">
-        <property name="use_action_appearance">False</property>
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="tooltip_text" translatable="yes">Copies the sharing secret to the clipboard</property>
-        <property name="label" translatable="yes">Copy secret</property>
-        <property name="use_underline">True</property>
-        <signal name="activate" handler="onFoldersCopySecret" swapped="no"/>
-      </object>
-    </child>
-    <child>
-      <object class="GtkMenuItem" id="folder_menu_connect">
-        <property name="use_action_appearance">False</property>
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="tooltip_text" translatable="yes">Displays a QR-code that permits easy connection of a mobile device to this folder</property>
-        <property name="label" translatable="yes">Connect mobile device</property>
-        <property name="use_underline">True</property>
-        <signal name="activate" handler="onFoldersConnectMobile" swapped="no"/>
-      </object>
-    </child>
-    <child>
-      <object class="GtkMenuItem" id="folder_menu_openfolder">
-        <property name="use_action_appearance">False</property>
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="tooltip_text" translatable="yes">Opens the folder in the file manager</property>
-        <property name="label" translatable="yes">Open Folder</property>
-        <property name="use_underline">True</property>
-        <signal name="activate" handler="onFoldersOpenFolder" swapped="no"/>
-      </object>
-    </child>
-    <child>
-      <object class="GtkMenuItem" id="folder_menu_openarchive">
-        <property name="use_action_appearance">False</property>
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="tooltip_text" translatable="yes">Opens the sync archive holding previous or deleted versions of files</property>
-        <property name="label" translatable="yes">Open SyncArchive</property>
-        <property name="use_underline">True</property>
-        <signal name="activate" handler="onFoldersOpenArchive" swapped="no"/>
-      </object>
-    </child>
-    <child>
-      <object class="GtkMenuItem" id="folder_menu_editsyncignore">
-        <property name="use_action_appearance">False</property>
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="tooltip_text" translatable="yes">Edit the file containing the list or filename patterns for file not being synced</property>
-        <property name="label" translatable="yes">Edit .SyncIgnore</property>
-        <property name="use_underline">True</property>
-        <signal name="activate" handler="onFoldersEditSyncIgnore" swapped="no"/>
-      </object>
-    </child>
-    <child>
-      <object class="GtkMenuItem" id="folder_menu_prefs">
-        <property name="use_action_appearance">False</property>
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="tooltip_text" translatable="yes">Opens the preferences dialog for the shared folder</property>
-        <property name="label" translatable="yes">Show folder preferences</property>
-        <property name="use_underline">True</property>
-        <signal name="activate" handler="onFoldersPreferences" swapped="no"/>
-      </object>
-    </child>
-  </object>
-  <object class="GtkListStore" id="history_list">
-    <columns>
-      <!-- column-name Date -->
-      <column type="gchararray"/>
-      <!-- column-name Event -->
-      <column type="gchararray"/>
-      <!-- column-name EllipsizeMode -->
-      <column type="gint"/>
-    </columns>
-  </object>
   <object class="GtkWindow" id="btsyncapp">
     <property name="can_focus">False</property>
     <property name="border_width">12</property>
@@ -806,8 +692,254 @@
             <property name="tab_fill">False</property>
           </packing>
         </child>
+        <child>
+          <object class="GtkGrid" id="settings_grid">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="margin_left">6</property>
+            <property name="margin_right">6</property>
+            <property name="margin_top">6</property>
+            <property name="margin_bottom">6</property>
+            <property name="row_spacing">3</property>
+            <property name="column_spacing">3</property>
+            <child>
+              <object class="GtkCheckButton" id="enableWebUI">
+                <property name="label" translatable="yes">Enable Access to Web UI</property>
+                <property name="use_action_appearance">False</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="use_action_appearance">False</property>
+                <property name="xalign">0</property>
+                <property name="draw_indicator">True</property>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">2</property>
+                <property name="width">1</property>
+                <property name="height">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkCheckButton" id="enableDarkIcons">
+                <property name="label" translatable="yes">Enable Dark Icon Set</property>
+                <property name="use_action_appearance">False</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="use_action_appearance">False</property>
+                <property name="xalign">0</property>
+                <property name="draw_indicator">True</property>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">0</property>
+                <property name="width">2</property>
+                <property name="height">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkCheckButton" id="enableFolderMenu">
+                <property name="label" translatable="yes">Enable Folder Display in Menu</property>
+                <property name="use_action_appearance">False</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="use_action_appearance">False</property>
+                <property name="xalign">0</property>
+                <property name="draw_indicator">True</property>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">1</property>
+                <property name="width">2</property>
+                <property name="height">1</property>
+              </packing>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <object class="GtkButton" id="buttonAdvanced">
+                <property name="label" translatable="yes">Advanced</property>
+                <property name="use_action_appearance">False</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_action_appearance">False</property>
+              </object>
+              <packing>
+                <property name="left_attach">2</property>
+                <property name="top_attach">2</property>
+                <property name="width">1</property>
+                <property name="height">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="position">5</property>
+          </packing>
+        </child>
+        <child type="tab">
+          <object class="GtkLabel" id="labelSettings">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label" translatable="yes">Settings</property>
+          </object>
+          <packing>
+            <property name="position">5</property>
+            <property name="tab_fill">False</property>
+          </packing>
+        </child>
       </object>
     </child>
+  </object>
+  <object class="GtkListStore" id="devices_list">
+    <columns>
+      <!-- column-name Device -->
+      <column type="gchararray"/>
+      <!-- column-name Folder -->
+      <column type="gchararray"/>
+      <!-- column-name Status -->
+      <column type="gchararray"/>
+      <!-- column-name Secret -->
+      <column type="gchararray"/>
+      <!-- column-name FolderTag -->
+      <column type="gchararray"/>
+      <!-- column-name DeviceTag -->
+      <column type="gchararray"/>
+      <!-- column-name ConnectionIconName -->
+      <column type="gchararray"/>
+      <!-- column-name EllipsizeMode -->
+      <column type="gint"/>
+    </columns>
+  </object>
+  <object class="GtkListStore" id="folders_list">
+    <columns>
+      <!-- column-name Folder -->
+      <column type="gchararray"/>
+      <!-- column-name Content -->
+      <column type="gchararray"/>
+      <!-- column-name Secret -->
+      <column type="gchararray"/>
+      <!-- column-name FolderTag -->
+      <column type="gchararray"/>
+      <!-- column-name EllipsizeMode -->
+      <column type="gint"/>
+    </columns>
+  </object>
+  <object class="GtkMenu" id="folders_menu">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <child>
+      <object class="GtkMenuItem" id="folder_menu_copy">
+        <property name="use_action_appearance">False</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="tooltip_text" translatable="yes">Copies the sharing secret to the clipboard</property>
+        <property name="label" translatable="yes">Copy secret</property>
+        <property name="use_underline">True</property>
+        <signal name="activate" handler="onFoldersCopySecret" swapped="no"/>
+      </object>
+    </child>
+    <child>
+      <object class="GtkMenuItem" id="folder_menu_connect">
+        <property name="use_action_appearance">False</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="tooltip_text" translatable="yes">Displays a QR-code that permits easy connection of a mobile device to this folder</property>
+        <property name="label" translatable="yes">Connect mobile device</property>
+        <property name="use_underline">True</property>
+        <signal name="activate" handler="onFoldersConnectMobile" swapped="no"/>
+      </object>
+    </child>
+    <child>
+      <object class="GtkMenuItem" id="folder_menu_openfolder">
+        <property name="use_action_appearance">False</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="tooltip_text" translatable="yes">Opens the folder in the file manager</property>
+        <property name="label" translatable="yes">Open Folder</property>
+        <property name="use_underline">True</property>
+        <signal name="activate" handler="onFoldersOpenFolder" swapped="no"/>
+      </object>
+    </child>
+    <child>
+      <object class="GtkMenuItem" id="folder_menu_openarchive">
+        <property name="use_action_appearance">False</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="tooltip_text" translatable="yes">Opens the sync archive holding previous or deleted versions of files</property>
+        <property name="label" translatable="yes">Open SyncArchive</property>
+        <property name="use_underline">True</property>
+        <signal name="activate" handler="onFoldersOpenArchive" swapped="no"/>
+      </object>
+    </child>
+    <child>
+      <object class="GtkMenuItem" id="folder_menu_editsyncignore">
+        <property name="use_action_appearance">False</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="tooltip_text" translatable="yes">Edit the file containing the list or filename patterns for file not being synced</property>
+        <property name="label" translatable="yes">Edit .SyncIgnore</property>
+        <property name="use_underline">True</property>
+        <signal name="activate" handler="onFoldersEditSyncIgnore" swapped="no"/>
+      </object>
+    </child>
+    <child>
+      <object class="GtkMenuItem" id="folder_menu_prefs">
+        <property name="use_action_appearance">False</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="tooltip_text" translatable="yes">Opens the preferences dialog for the shared folder</property>
+        <property name="label" translatable="yes">Show folder preferences</property>
+        <property name="use_underline">True</property>
+        <signal name="activate" handler="onFoldersPreferences" swapped="no"/>
+      </object>
+    </child>
+  </object>
+  <object class="GtkListStore" id="history_list">
+    <columns>
+      <!-- column-name Date -->
+      <column type="gchararray"/>
+      <!-- column-name Event -->
+      <column type="gchararray"/>
+      <!-- column-name EllipsizeMode -->
+      <column type="gint"/>
+    </columns>
   </object>
   <object class="GtkListStore" id="transfers_list">
     <columns>

--- a/btsync-gui/btsyncapp.py
+++ b/btsync-gui/btsyncapp.py
@@ -33,12 +33,13 @@ from gi.repository import Gtk, Gdk, GObject, Pango
 
 from btsyncagent import BtSyncAgent
 from btsyncutils import BtInputHelper,BtMessageHelper,BtValueDescriptor,BtDynamicTimeout
-from dialogs import BtSyncFolderAdd,BtSyncFolderRemove,BtSyncFolderScanQR,BtSyncFolderPrefs,BtSyncPrefsAdvanced
+from dialogs import BtSyncFolderAdd,BtSyncFolderRemove,BtSyncFolderScanQR,BtSyncFolderPrefs,BtSyncPrefsAdvanced,BtSyncSettingsAdvanced
 
 class BtSyncApp(BtInputHelper,BtMessageHelper):
 
-	def __init__(self,agent):
-		self.agent = agent
+	def __init__(self,agent,status=None):
+		self.agent	= agent
+		self.status	= status
 
 		self.builder = Gtk.Builder()
 		self.builder.set_translation_domain('btsync-gui')
@@ -84,6 +85,7 @@ class BtSyncApp(BtInputHelper,BtMessageHelper):
 
 		self.init_folders_values()
 		self.init_preferences_values()
+		self.init_settings_values()
 
 	def close(self):
 		self.app_status_to.stop()
@@ -388,7 +390,7 @@ class BtSyncApp(BtInputHelper,BtMessageHelper):
 	def init_settings_values(self):
 		self.lock()
 		self.attach(self.enableDarkIcons,BtValueDescriptor.new_from('dark',self.agent.dark))
-		self.attach(self.enableFoldersMenu,BtValueDescriptor.new_from('foldersMenu',self.agent.foldersmenu))
+		self.attach(self.enableFoldersMenu,BtValueDescriptor.new_from('foldersmenu',self.agent.foldersmenu))
 		self.attach(self.enableWebUI,BtValueDescriptor.new_from('webui',self.agent.webui))
 		self.unlock()
 
@@ -434,12 +436,20 @@ class BtSyncApp(BtInputHelper,BtMessageHelper):
 		self.close()
 
 	def onSaveEntry(self,widget,valDesc,newValue):
-		logging.error('Changed Setting: {0} {1}'.format(valDesc.Name, newValue))
+		logging.info('Changed Setting: {0} {1}'.format(valDesc.Name, newValue))
 		try:
 			if valDesc.is_local():
 				# local gui settings
-				self.agent.set_pref({valDesc.Name : newValue})
+				self.agent.set_pref(valDesc.Name, newValue)
 				self.agent.read_prefs ()
+				# make changes active
+				if valDesc.Name == 'dark' and self.status is not None:
+					self.status.init_icons()
+					self.status.refresh_status()
+				if valDesc.Name == 'webui' and self.status is not None:
+					self.status.refresh_menus()
+				if valDesc.Name == 'foldersmenu' and self.status is not None:
+					self.status.refresh_menus()
 			else:
 				# bittorrent sync settings
 				self.agent.set_prefs({valDesc.Name : newValue})
@@ -631,6 +641,19 @@ class BtSyncApp(BtInputHelper,BtMessageHelper):
 			logging.error('onPreferencesClickedAdvanced: Unexpected exception caught: '+str(e))
 		finally:
 			if isinstance(self.dlg, BtSyncPrefsAdvanced):
+				self.dlg.destroy()
+			self.dlg = None
+
+	def onSettingsClickedAdvanced(self,widget):
+		try:
+			self.dlg = BtSyncSettingsAdvanced(self.agent)
+			self.dlg.create()
+			self.dlg.run()
+		except Exception as e:
+			# this should not really happen...
+			logging.error('onPreferencesClickedAdvanced: Unexpected exception caught: '+str(e))
+		finally:
+			if isinstance(self.dlg, BtSyncSettingsAdvanced):
 				self.dlg.destroy()
 			self.dlg = None
 

--- a/btsync-gui/btsyncapp.py
+++ b/btsync-gui/btsyncapp.py
@@ -373,6 +373,7 @@ class BtSyncApp(BtInputHelper,BtMessageHelper):
 		self.attach(self.devname,BtValueDescriptor.new_from('device_name',self.prefs['device_name']))
 		# self.autostart.set_active(self.prefs[""]);
 		self.autostart.set_sensitive(False)
+		self.autostart.set_visible(False)
 		self.attach(self.listeningport,BtValueDescriptor.new_from('listening_port',self.prefs['listening_port']))
 		self.attach(self.upnp,BtValueDescriptor.new_from('use_upnp',self.prefs['use_upnp']))
 		self.attach(self.limitdnrate,BtValueDescriptor.new_from('download_limit',self.prefs['download_limit']))

--- a/btsync-gui/btsyncapp.py
+++ b/btsync-gui/btsyncapp.py
@@ -387,6 +387,10 @@ class BtSyncApp(BtInputHelper,BtMessageHelper):
 		self.enableDarkIcons = self.builder.get_object('enableDarkIcons')
 		self.enableFoldersMenu = self.builder.get_object('enableFoldersMenu')
 		self.enableWebUI = self.builder.get_object('enableWebUI')
+		self.buttonAdvanced = self.builder.get_object('buttonAdvanced')
+		# TODO: implement folder menus
+		self.enableFoldersMenu.set_sensitive(False)
+		self.buttonAdvanced.set_sensitive(self.agent.is_primary())
 
 	def init_settings_values(self):
 		self.lock()

--- a/btsync-gui/btsyncstatus.py
+++ b/btsync-gui/btsyncstatus.py
@@ -44,6 +44,7 @@ class BtSyncStatus:
 	PAUSED			= 3
 
 	def __init__(self,agent):
+		self.agent = agent
 		self.builder = Gtk.Builder()
 		self.builder.set_translation_domain('btsync-gui')
 		self.builder.add_from_file(os.path.dirname(__file__) + "/btsyncstatus.glade")
@@ -56,24 +57,14 @@ class BtSyncStatus:
 		self.menuopenweb = self.builder.get_object('openweb')
 		self.menuopenapp = self.builder.get_object('openapp')
 		self.about = self.builder.get_object('aboutdialog')
-		if agent.dark:
-			self.icn_disconnected = 'btsync-gui-disconnected-dark'
-			self.icn_connecting = 'btsync-gui-connecting-dark'
-			self.icn_paused = 'btsync-gui-paused-dark'
-			self.icn_idle = 'btsync-gui-0-dark'
-			self.icn_activity = 'btsync-gui-{0}-dark'
-		else:
-			self.icn_disconnected = 'btsync-gui-disconnected'
-			self.icn_connecting = 'btsync-gui-connecting'
-			self.icn_paused = 'btsync-gui-paused'
-			self.icn_idle = 'btsync-gui-0'
-			self.icn_activity = 'btsync-gui-{0}'
 
+		self.init_icons()
 
 		self.ind = TrayIndicator (
 			'btsync',
 			self.icn_disconnected
 		)
+
 		if agent.is_auto():
 			self.menuconnection.set_visible(False)
 			self.ind.set_title(_('BitTorrent Sync'))
@@ -82,9 +73,10 @@ class BtSyncStatus:
 			self.menuconnection.set_label('{0}:{1}'.format(agent.get_host(),agent.get_port()))
 			self.ind.set_title(_('BitTorrent Sync {0}:{1}').format(agent.get_host(),agent.get_port()))
 			self.ind.set_tooltip_text(_('BitTorrent Sync {0}:{1}').format(agent.get_host(),agent.get_port()))
-#		self.menuopenweb.set_visible(agent.is_webui())
+
 		self.ind.set_menu(self.menu)
 		self.ind.set_default_action(self.onActivate)
+		self.refresh_menus()
 
 		# icon animator
 		self.frame = 0
@@ -99,7 +91,6 @@ class BtSyncStatus:
 		self.connection = BtSyncStatus.DISCONNECTED
 		self.connect_id = None
 		self.status_to = BtDynamicTimeout(1000,self.btsync_refresh_status)
-		self.agent = agent
 
 	def startup(self):
 		self.btsyncver = { 'version': '0.0.0' }
@@ -131,7 +122,7 @@ class BtSyncStatus:
 			self.app.window.present()
 		else:
 			try:
-				self.app = BtSyncApp(self.agent)
+				self.app = BtSyncApp(self.agent,self)
 				self.app.connect_close_signal(self.onDeleteApp)
 			except requests.exceptions.ConnectionError:
 				return self.onConnectionError()
@@ -146,6 +137,20 @@ class BtSyncStatus:
 				self.app.window.destroy()
 			del self.app
 			self.app = None
+
+	def init_icons(self):
+		if self.agent.is_dark():
+			self.icn_disconnected = 'btsync-gui-disconnected-dark'
+			self.icn_connecting = 'btsync-gui-connecting-dark'
+			self.icn_paused = 'btsync-gui-paused-dark'
+			self.icn_idle = 'btsync-gui-0-dark'
+			self.icn_activity = 'btsync-gui-{0}-dark'
+		else:
+			self.icn_disconnected = 'btsync-gui-disconnected'
+			self.icn_connecting = 'btsync-gui-connecting'
+			self.icn_paused = 'btsync-gui-paused'
+			self.icn_idle = 'btsync-gui-0'
+			self.icn_activity = 'btsync-gui-{0}'
 
 	def btsync_connect(self):
 		if self.connection is BtSyncStatus.DISCONNECTED or \
@@ -251,11 +256,17 @@ class BtSyncStatus:
 				self.ind.set_from_icon_name(self.icn_idle)
 		self.connection = connection
 
+	def refresh_status(self):
+		self.set_status(self.connection,self.transferring)
+
 	def show_status(self,statustext):
 		self.menustatus.set_label(statustext)
 
 	def is_connected(self):
 		return self.connection is BtSyncStatus.CONNECTED
+
+	def refresh_menus(self):
+		self.menuopenweb.set_visible(self.agent.is_webui())
 
 	def onActivate(self,widget):
 #		self.menu.popup(None,None,Gtk.StatusIcon.position_menu,widget,3,0)
@@ -278,7 +289,7 @@ class BtSyncStatus:
 			urllib.quote(self.agent.get_password(),''),
 			self.agent.get_host(),
 			self.agent.get_port()
-		), 2)
+		), new = 2, autoraise = True)
 
 	def onDeleteApp(self, *args):
 		self.close_app(False)

--- a/btsync-gui/btsyncutils.py
+++ b/btsync-gui/btsyncutils.py
@@ -32,7 +32,7 @@ from gi.repository import Gtk, GObject
 
 class BtValueDescriptor(GObject.GObject):
 
-	def __init__(self, Name, Type, Value, Default='', Min=None, Max=None, Allowed=None, Forbidden=None, Advanced=True, Hidden=False):
+	def __init__(self, Name, Type, Value, Default='', Min=None, Max=None, Allowed=None, Forbidden=None, Advanced=True, Hidden=False, Local=False):
 		GObject.GObject.__init__(self)
 		self.Name		= Name
 		self.Type		= Type
@@ -44,6 +44,7 @@ class BtValueDescriptor(GObject.GObject):
 		self.Forbidden	= Forbidden
 		self.Advanced	= Advanced
 		self.Hidden		= Hidden
+		self.Local		= Local
 		if self.Type == 'n' and self.Allowed is None:
 			self.Allowed = '0123456789'
 			if str(self.Value)[0:1] == '*':	# remove these stupid "I'm not a default value!"-stars from data
@@ -60,6 +61,12 @@ class BtValueDescriptor(GObject.GObject):
 
 	def is_default(self,value):
 		return False if self.Default is None else str(self.Default) == str(value)
+
+	def is_hidden(self):
+		return self.Hidden
+
+	def is_local(self):
+		return self.Local
 
 	def set_default(self):
 		self.Value = self.Default
@@ -137,6 +144,12 @@ class BtValueDescriptor(GObject.GObject):
 		'sync_trash_ttl'					: BtValueDescriptor (Name, 'n', Value, 30, 0, 999999),
 		'upload_limit'						: BtValueDescriptor (Name, 'n', Value, 0, 0, 1000000, Advanced = False),
 		'use_upnp'							: BtValueDescriptor (Name, 'b', Value, 1, Advanced = False),
+		# the following values are not from btsync but only for the gui itself
+		'dark'								: BtValueDescriptor (Name, 'b', Value, False, Local=True),
+		'foldersmenu'						: BtValueDescriptor (Name, 'b', Value, False, Local=True),
+		'webui'								: BtValueDescriptor (Name, 'b', Value, True, Local=True),
+		'username'							: BtValueDescriptor (Name, 's', Value, Forbidden="\"'", Local=True),
+		'password'							: BtValueDescriptor (Name, 's', Value, Local=True)
 		}.get(Name,BtValueDescriptor (Name, 'u', Value, Hidden = True))
 
 	@staticmethod

--- a/btsync-gui/dialogs.glade
+++ b/btsync-gui/dialogs.glade
@@ -517,7 +517,7 @@
                     <property name="xalign">0</property>
                     <property name="active">True</property>
                     <property name="draw_indicator">True</property>
-                    <signal name="toggled" handler="onBindLocalHost" swapped="no"/>
+                    <signal name="toggled" handler="onChanged" swapped="no"/>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -536,7 +536,7 @@
                     <property name="active">True</property>
                     <property name="draw_indicator">True</property>
                     <property name="group">bind_local</property>
-                    <signal name="toggled" handler="onBindAll" swapped="no"/>
+                    <signal name="toggled" handler="onChanged" swapped="no"/>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -594,6 +594,7 @@
                 <property name="climb_rate">1</property>
                 <property name="numeric">True</property>
                 <property name="value">8080</property>
+                <signal name="value-changed" handler="onChanged" swapped="no"/>
               </object>
               <packing>
                 <property name="left_attach">2</property>

--- a/btsync-gui/dialogs.glade
+++ b/btsync-gui/dialogs.glade
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.16.1 -->
 <interface>
-  <!-- interface-requires gtk+ 3.0 -->
+  <requires lib="gtk+" version="3.0"/>
   <object class="GtkDialog" id="addfolder">
     <property name="can_focus">False</property>
     <property name="border_width">5</property>
@@ -26,7 +27,6 @@
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_action_appearance">False</property>
                 <property name="use_stock">True</property>
               </object>
               <packing>
@@ -42,7 +42,6 @@
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_action_appearance">False</property>
                 <property name="use_stock">True</property>
               </object>
               <packing>
@@ -129,7 +128,6 @@
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_action_appearance">False</property>
                 <signal name="clicked" handler="onFolderAddGenerate" swapped="no"/>
               </object>
               <packing>
@@ -147,7 +145,6 @@
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
                 <property name="margin_top">12</property>
-                <property name="use_action_appearance">False</property>
                 <signal name="clicked" handler="onFolderAddChoose" swapped="no"/>
               </object>
               <packing>
@@ -201,7 +198,666 @@
       <column type="GObject"/>
     </columns>
   </object>
+  <object class="GtkDialog" id="prefsadvanced">
+    <property name="can_focus">False</property>
+    <property name="border_width">5</property>
+    <property name="title" translatable="yes">Advanced Preferences</property>
+    <property name="modal">True</property>
+    <property name="window_position">mouse</property>
+    <property name="destroy_with_parent">True</property>
+    <property name="icon_name">btsync-gui</property>
+    <property name="type_hint">dialog</property>
+    <property name="skip_taskbar_hint">True</property>
+    <child internal-child="vbox">
+      <object class="GtkBox" id="dialog-vbox5">
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox" id="dialog-action_area5">
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
+            <child>
+              <object class="GtkLabel" id="ap_label_value">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="xalign">0</property>
+                <property name="label" translatable="yes">Value:</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkSwitch" id="ap_switch_value">
+                <property name="use_action_appearance">False</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkEntry" id="ap_entry_value">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="invisible_char">●</property>
+                <property name="shadow_type">none</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="ap_reset_value">
+                <property name="label" translatable="yes">Reset</property>
+                <property name="use_action_appearance">False</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <signal name="clicked" handler="onPrefsAdvancedResetValue" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">3</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="ap_close_button">
+                <property name="label">gtk-close</property>
+                <property name="use_action_appearance">False</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="pack_type">end</property>
+                <property name="position">4</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="pack_type">end</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkScrolledWindow" id="scrolledwindow5">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="shadow_type">etched-in</property>
+            <property name="min_content_width">500</property>
+            <property name="min_content_height">190</property>
+            <child>
+              <object class="GtkTreeView" id="ap_tree_prefs">
+                <property name="height_request">190</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="vscroll_policy">natural</property>
+                <property name="model">advancedprefs</property>
+                <property name="headers_clickable">False</property>
+                <child internal-child="selection">
+                  <object class="GtkTreeSelection" id="treeview-selection2">
+                    <signal name="changed" handler="onSelectionChanged" swapped="no"/>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkTreeViewColumn" id="treeviewcolumn1">
+                    <property name="title" translatable="yes">Name</property>
+                    <property name="sort_indicator">True</property>
+                    <property name="sort_column_id">0</property>
+                    <child>
+                      <object class="GtkCellRendererText" id="cellrenderertext1"/>
+                      <attributes>
+                        <attribute name="text">0</attribute>
+                      </attributes>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkTreeViewColumn" id="treeviewcolumn2">
+                    <property name="title" translatable="yes">Value</property>
+                    <child>
+                      <object class="GtkCellRendererText" id="cellrenderertext2"/>
+                      <attributes>
+                        <attribute name="text">1</attribute>
+                        <attribute name="weight">2</attribute>
+                      </attributes>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <action-widgets>
+      <action-widget response="0">ap_reset_value</action-widget>
+      <action-widget response="-5">ap_close_button</action-widget>
+    </action-widgets>
+  </object>
+  <object class="GtkDialog" id="advsettings">
+    <property name="can_focus">False</property>
+    <property name="modal">True</property>
+    <property name="destroy_with_parent">True</property>
+    <property name="type_hint">dialog</property>
+    <property name="skip_taskbar_hint">True</property>
+    <child internal-child="vbox">
+      <object class="GtkBox" id="dialog-vbox9">
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox" id="dialog-action_area9">
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
+            <child>
+              <object class="GtkButton" id="button8">
+                <property name="label">gtk-cancel</property>
+                <property name="use_action_appearance">False</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
+                <property name="image_position">bottom</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="button6">
+                <property name="label">gtk-ok</property>
+                <property name="use_action_appearance">False</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="pack_type">end</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkGrid" id="grid3">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="margin_left">12</property>
+            <property name="margin_right">12</property>
+            <property name="margin_top">12</property>
+            <property name="margin_bottom">4</property>
+            <property name="row_spacing">6</property>
+            <property name="column_spacing">6</property>
+            <child>
+              <object class="GtkLabel" id="password_label">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="xalign">0</property>
+                <property name="label" translatable="yes">Password:</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">2</property>
+                <property name="width">1</property>
+                <property name="height">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkEntry" id="username_value">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <signal name="changed" handler="onChanged" swapped="no"/>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">1</property>
+                <property name="width">2</property>
+                <property name="height">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="username_label">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="xalign">0</property>
+                <property name="label" translatable="yes">User Name:</property>
+                <property name="ellipsize">end</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">1</property>
+                <property name="width">1</property>
+                <property name="height">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="label12">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="xalign">0</property>
+                <property name="label" translatable="yes">If you specify any credentials, the Web UI of Sync will be secured with the specified credentials, otherwise random credentials are created at any application start.</property>
+                <property name="wrap">True</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">0</property>
+                <property name="width">3</property>
+                <property name="height">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkSeparator" id="separator1">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">3</property>
+                <property name="width">3</property>
+                <property name="height">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="bindaddr_label">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="xalign">0</property>
+                <property name="label" translatable="yes">Bind Address:</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">4</property>
+                <property name="width">1</property>
+                <property name="height">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButtonBox" id="buttonbox2">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="layout_style">start</property>
+                <child>
+                  <object class="GtkRadioButton" id="bind_local">
+                    <property name="label" translatable="yes">Local Host</property>
+                    <property name="use_action_appearance">False</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="xalign">0</property>
+                    <property name="active">True</property>
+                    <property name="draw_indicator">True</property>
+                    <signal name="toggled" handler="onBindLocalHost" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkRadioButton" id="bind_all">
+                    <property name="label" translatable="yes">All</property>
+                    <property name="use_action_appearance">False</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="xalign">0</property>
+                    <property name="active">True</property>
+                    <property name="draw_indicator">True</property>
+                    <property name="group">bind_local</property>
+                    <signal name="toggled" handler="onBindAll" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkRadioButton" id="bind_other">
+                    <property name="label" translatable="yes">Other</property>
+                    <property name="use_action_appearance">False</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="xalign">0</property>
+                    <property name="active">True</property>
+                    <property name="draw_indicator">True</property>
+                    <property name="group">bind_local</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">4</property>
+                <property name="width">2</property>
+                <property name="height">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkCheckButton" id="bindport_set">
+                <property name="label" translatable="yes">Bind Port:</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="xalign">0</property>
+                <property name="draw_indicator">True</property>
+                <signal name="toggled" handler="onBindPortToggled" swapped="no"/>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">5</property>
+                <property name="width">1</property>
+                <property name="height">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkSpinButton" id="bindport_value">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="climb_rate">1</property>
+                <property name="numeric">True</property>
+                <property name="value">8080</property>
+              </object>
+              <packing>
+                <property name="left_attach">2</property>
+                <property name="top_attach">5</property>
+                <property name="width">1</property>
+                <property name="height">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkEntry" id="password_value">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="visibility">False</property>
+                <signal name="changed" handler="onChanged" swapped="no"/>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">2</property>
+                <property name="width">2</property>
+                <property name="height">1</property>
+              </packing>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <action-widgets>
+      <action-widget response="-6">button8</action-widget>
+      <action-widget response="-5">button6</action-widget>
+    </action-widgets>
+  </object>
   <object class="GtkTextBuffer" id="en_secret_text"/>
+  <object class="GtkListStore" id="fp_predefined_hosts">
+    <columns>
+      <!-- column-name Host -->
+      <column type="gchararray"/>
+    </columns>
+  </object>
+  <object class="GtkDialog" id="newhost">
+    <property name="can_focus">False</property>
+    <property name="border_width">5</property>
+    <property name="title" translatable="yes">New Predefined Host</property>
+    <property name="modal">True</property>
+    <property name="destroy_with_parent">True</property>
+    <property name="icon_name">btsync-gui</property>
+    <property name="type_hint">dialog</property>
+    <property name="skip_taskbar_hint">True</property>
+    <child internal-child="vbox">
+      <object class="GtkBox" id="dialog-vbox7">
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox" id="dialog-action_area7">
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="pack_type">end</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="box7">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <child>
+              <object class="GtkLabel" id="label7">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">New known host address:</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkEntry" id="ph_addr">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="invisible_char">●</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="label8">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">:</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkEntry" id="ph_port">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="max_length">5</property>
+                <property name="invisible_char">●</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">3</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
+  <object class="GtkTextBuffer" id="ot_secret_text"/>
+  <object class="GtkAdjustment" id="port_adjustment">
+    <property name="lower">8000</property>
+    <property name="upper">65534</property>
+    <property name="value">8080</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+  </object>
+  <object class="GtkDialog" id="removefolder">
+    <property name="can_focus">False</property>
+    <property name="border_width">5</property>
+    <property name="title" translatable="yes">Remove Shared Folder</property>
+    <property name="resizable">False</property>
+    <property name="modal">True</property>
+    <property name="default_width">320</property>
+    <property name="default_height">260</property>
+    <property name="destroy_with_parent">True</property>
+    <property name="icon_name">btsync-gui</property>
+    <property name="type_hint">dialog</property>
+    <property name="skip_taskbar_hint">True</property>
+    <property name="has_resize_grip">False</property>
+    <child internal-child="vbox">
+      <object class="GtkBox" id="dialog-vbox1">
+        <property name="can_focus">False</property>
+        <property name="margin_top">24</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox" id="dialog-action_area1">
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
+            <child>
+              <object class="GtkButton" id="button2">
+                <property name="label">gtk-cancel</property>
+                <property name="use_action_appearance">False</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
+                <property name="image_position">right</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="button1">
+                <property name="label">gtk-ok</property>
+                <property name="use_action_appearance">False</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="pack_type">end</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="box1">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="spacing">24</property>
+            <child>
+              <object class="GtkImage" id="image1">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="pixel_size">64</property>
+                <property name="icon_name">btsync-gui</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="label1">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="yalign">0</property>
+                <property name="label" translatable="yes">This folder will be removed from BitTorrent Sync and no longer synced with other devices</property>
+                <property name="wrap">True</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <action-widgets>
+      <action-widget response="-75">button2</action-widget>
+      <action-widget response="-5">button1</action-widget>
+    </action-widgets>
+  </object>
+  <object class="GtkTextBuffer" id="ro_secret_text"/>
+  <object class="GtkTextBuffer" id="rw_secret_text">
+    <signal name="changed" handler="onSecretChanged" swapped="no"/>
+  </object>
   <object class="GtkDialog" id="folderprefs">
     <property name="can_focus">False</property>
     <property name="border_width">5</property>
@@ -228,7 +884,6 @@
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_action_appearance">False</property>
                 <property name="use_stock">True</property>
               </object>
               <packing>
@@ -244,7 +899,6 @@
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_action_appearance">False</property>
                 <property name="use_stock">True</property>
                 <signal name="clicked" handler="onOK" swapped="no"/>
               </object>
@@ -320,7 +974,6 @@
                         <property name="sensitive">False</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="xalign">0</property>
                         <property name="active">True</property>
                         <property name="draw_indicator">True</property>
@@ -340,7 +993,6 @@
                         <property name="sensitive">False</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="xalign">0</property>
                         <property name="draw_indicator">True</property>
                       </object>
@@ -447,7 +1099,6 @@
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="use_stock">True</property>
                         <signal name="clicked" handler="onRwSecretCopy" swapped="no"/>
                       </object>
@@ -464,7 +1115,6 @@
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="use_stock">True</property>
                         <signal name="clicked" handler="onRwSecretNew" swapped="no"/>
                       </object>
@@ -496,7 +1146,6 @@
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="use_stock">True</property>
                         <signal name="clicked" handler="onRoSecretCopy" swapped="no"/>
                       </object>
@@ -540,7 +1189,6 @@
                         <property name="sensitive">False</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="use_stock">True</property>
                       </object>
                       <packing>
@@ -557,7 +1205,6 @@
                         <property name="sensitive">False</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="use_stock">True</property>
                         <signal name="clicked" handler="onOtSecretCopy" swapped="no"/>
                       </object>
@@ -606,7 +1253,6 @@
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">False</property>
-                    <property name="use_action_appearance">False</property>
                     <property name="xalign">0</property>
                     <property name="draw_indicator">True</property>
                     <signal name="toggled" handler="onChanged" swapped="no"/>
@@ -666,7 +1312,6 @@ on other devices.</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="use_stock">True</property>
                         <signal name="clicked" handler="onEnSecretCopy" swapped="no"/>
                       </object>
@@ -758,7 +1403,6 @@ on other devices.</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">False</property>
-                    <property name="use_action_appearance">False</property>
                     <property name="xalign">0</property>
                     <property name="draw_indicator">True</property>
                     <signal name="toggled" handler="onChanged" swapped="no"/>
@@ -776,7 +1420,6 @@ on other devices.</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">False</property>
-                    <property name="use_action_appearance">False</property>
                     <property name="xalign">0</property>
                     <property name="draw_indicator">True</property>
                     <signal name="toggled" handler="onChanged" swapped="no"/>
@@ -794,7 +1437,6 @@ on other devices.</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">False</property>
-                    <property name="use_action_appearance">False</property>
                     <property name="xalign">0</property>
                     <property name="draw_indicator">True</property>
                     <signal name="toggled" handler="onChanged" swapped="no"/>
@@ -812,7 +1454,6 @@ on other devices.</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">False</property>
-                    <property name="use_action_appearance">False</property>
                     <property name="xalign">0</property>
                     <property name="draw_indicator">True</property>
                     <signal name="toggled" handler="onChanged" swapped="no"/>
@@ -830,7 +1471,6 @@ on other devices.</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">False</property>
-                    <property name="use_action_appearance">False</property>
                     <property name="xalign">0</property>
                     <property name="draw_indicator">True</property>
                     <signal name="toggled" handler="onChanged" swapped="no"/>
@@ -848,7 +1488,6 @@ on other devices.</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">False</property>
-                    <property name="use_action_appearance">False</property>
                     <property name="xalign">0</property>
                     <property name="draw_indicator">True</property>
                     <signal name="toggled" handler="onPredefinedToggle" swapped="no"/>
@@ -910,7 +1549,6 @@ on other devices.</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="use_stock">True</property>
                         <signal name="clicked" handler="onPredefinedAdd" swapped="no"/>
                       </object>
@@ -927,7 +1565,6 @@ on other devices.</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="use_stock">True</property>
                         <signal name="clicked" handler="onPredefinedRemove" swapped="no"/>
                       </object>
@@ -994,385 +1631,6 @@ on other devices.</property>
       <action-widget response="-5">fp_button_ok</action-widget>
     </action-widgets>
   </object>
-  <object class="GtkListStore" id="fp_predefined_hosts">
-    <columns>
-      <!-- column-name Host -->
-      <column type="gchararray"/>
-    </columns>
-  </object>
-  <object class="GtkDialog" id="newhost">
-    <property name="can_focus">False</property>
-    <property name="border_width">5</property>
-    <property name="title" translatable="yes">New Predefined Host</property>
-    <property name="modal">True</property>
-    <property name="destroy_with_parent">True</property>
-    <property name="icon_name">btsync-gui</property>
-    <property name="type_hint">dialog</property>
-    <property name="skip_taskbar_hint">True</property>
-    <child internal-child="vbox">
-      <object class="GtkBox" id="dialog-vbox7">
-        <property name="can_focus">False</property>
-        <property name="orientation">vertical</property>
-        <property name="spacing">2</property>
-        <child internal-child="action_area">
-          <object class="GtkButtonBox" id="dialog-action_area7">
-            <property name="can_focus">False</property>
-            <property name="layout_style">end</property>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="pack_type">end</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkBox" id="box7">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <child>
-              <object class="GtkLabel" id="label7">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">New known host address:</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkEntry" id="ph_addr">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="invisible_char">●</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="label8">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">:</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">2</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkEntry" id="ph_port">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="max_length">5</property>
-                <property name="invisible_char">●</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">3</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
-      </object>
-    </child>
-  </object>
-  <object class="GtkTextBuffer" id="ot_secret_text"/>
-  <object class="GtkDialog" id="prefsadvanced">
-    <property name="can_focus">False</property>
-    <property name="border_width">5</property>
-    <property name="title" translatable="yes">Advanced Preferences</property>
-    <property name="modal">True</property>
-    <property name="window_position">mouse</property>
-    <property name="destroy_with_parent">True</property>
-    <property name="icon_name">btsync-gui</property>
-    <property name="type_hint">dialog</property>
-    <property name="skip_taskbar_hint">True</property>
-    <child internal-child="vbox">
-      <object class="GtkBox" id="dialog-vbox5">
-        <property name="can_focus">False</property>
-        <property name="orientation">vertical</property>
-        <property name="spacing">2</property>
-        <child internal-child="action_area">
-          <object class="GtkButtonBox" id="dialog-action_area5">
-            <property name="can_focus">False</property>
-            <property name="layout_style">end</property>
-            <child>
-              <object class="GtkLabel" id="ap_label_value">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="xalign">0</property>
-                <property name="label" translatable="yes">Value:</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkSwitch" id="ap_switch_value">
-                <property name="use_action_appearance">False</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="use_action_appearance">False</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkEntry" id="ap_entry_value">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="invisible_char">●</property>
-                <property name="shadow_type">none</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">2</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="ap_reset_value">
-                <property name="label" translatable="yes">Reset</property>
-                <property name="use_action_appearance">False</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_action_appearance">False</property>
-                <signal name="clicked" handler="onPrefsAdvancedResetValue" swapped="no"/>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">3</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="ap_close_button">
-                <property name="label">gtk-close</property>
-                <property name="use_action_appearance">False</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_action_appearance">False</property>
-                <property name="use_stock">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="pack_type">end</property>
-                <property name="position">4</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="pack_type">end</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkScrolledWindow" id="scrolledwindow5">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="shadow_type">etched-in</property>
-            <property name="min_content_width">500</property>
-            <property name="min_content_height">190</property>
-            <child>
-              <object class="GtkTreeView" id="ap_tree_prefs">
-                <property name="height_request">190</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="vscroll_policy">natural</property>
-                <property name="model">advancedprefs</property>
-                <property name="headers_clickable">False</property>
-                <child internal-child="selection">
-                  <object class="GtkTreeSelection" id="treeview-selection2">
-                    <signal name="changed" handler="onSelectionChanged" swapped="no"/>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkTreeViewColumn" id="treeviewcolumn1">
-                    <property name="title" translatable="yes">Name</property>
-                    <property name="sort_indicator">True</property>
-                    <property name="sort_column_id">0</property>
-                    <child>
-                      <object class="GtkCellRendererText" id="cellrenderertext1"/>
-                      <attributes>
-                        <attribute name="text">0</attribute>
-                      </attributes>
-                    </child>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkTreeViewColumn" id="treeviewcolumn2">
-                    <property name="title" translatable="yes">Value</property>
-                    <child>
-                      <object class="GtkCellRendererText" id="cellrenderertext2"/>
-                      <attributes>
-                        <attribute name="text">1</attribute>
-                        <attribute name="weight">2</attribute>
-                      </attributes>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
-      </object>
-    </child>
-    <action-widgets>
-      <action-widget response="0">ap_reset_value</action-widget>
-      <action-widget response="-5">ap_close_button</action-widget>
-    </action-widgets>
-  </object>
-  <object class="GtkDialog" id="removefolder">
-    <property name="can_focus">False</property>
-    <property name="border_width">5</property>
-    <property name="title" translatable="yes">Remove Shared Folder</property>
-    <property name="resizable">False</property>
-    <property name="modal">True</property>
-    <property name="default_width">320</property>
-    <property name="default_height">260</property>
-    <property name="destroy_with_parent">True</property>
-    <property name="icon_name">btsync-gui</property>
-    <property name="type_hint">dialog</property>
-    <property name="skip_taskbar_hint">True</property>
-    <property name="has_resize_grip">False</property>
-    <child internal-child="vbox">
-      <object class="GtkBox" id="dialog-vbox1">
-        <property name="can_focus">False</property>
-        <property name="margin_top">24</property>
-        <property name="orientation">vertical</property>
-        <property name="spacing">2</property>
-        <child internal-child="action_area">
-          <object class="GtkButtonBox" id="dialog-action_area1">
-            <property name="can_focus">False</property>
-            <property name="layout_style">end</property>
-            <child>
-              <object class="GtkButton" id="button2">
-                <property name="label">gtk-cancel</property>
-                <property name="use_action_appearance">False</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_action_appearance">False</property>
-                <property name="use_stock">True</property>
-                <property name="image_position">right</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="button1">
-                <property name="label">gtk-ok</property>
-                <property name="use_action_appearance">False</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_action_appearance">False</property>
-                <property name="use_stock">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="pack_type">end</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkBox" id="box1">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="spacing">24</property>
-            <child>
-              <object class="GtkImage" id="image1">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="pixel_size">64</property>
-                <property name="icon_name">btsync-gui</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="label1">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="yalign">0</property>
-                <property name="label" translatable="yes">This folder will be removed from BitTorrent Sync and no longer synced with other devices</property>
-                <property name="wrap">True</property>
-                <attributes>
-                  <attribute name="weight" value="bold"/>
-                </attributes>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
-      </object>
-    </child>
-    <action-widgets>
-      <action-widget response="-6">button2</action-widget>
-      <action-widget response="-5">button1</action-widget>
-    </action-widgets>
-  </object>
-  <object class="GtkTextBuffer" id="ro_secret_text"/>
-  <object class="GtkTextBuffer" id="rw_secret_text">
-    <signal name="changed" handler="onSecretChanged" swapped="no"/>
-  </object>
   <object class="GtkDialog" id="scanqr">
     <property name="can_focus">False</property>
     <property name="border_width">5</property>
@@ -1399,7 +1657,6 @@ on other devices.</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_action_appearance">False</property>
                 <property name="use_stock">True</property>
               </object>
               <packing>
@@ -1453,7 +1710,6 @@ device to connect sync folders</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="xalign">0</property>
                         <property name="active">True</property>
                         <property name="draw_indicator">True</property>
@@ -1473,7 +1729,6 @@ device to connect sync folders</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="xalign">0</property>
                         <property name="active">True</property>
                         <property name="draw_indicator">True</property>

--- a/btsync-gui/dialogs.py
+++ b/btsync-gui/dialogs.py
@@ -25,6 +25,7 @@ import os
 import gettext
 import qrencode
 import requests
+import logging
 
 from gettext import gettext as _
 from gi.repository import Gtk, Gdk, GdkPixbuf
@@ -493,6 +494,79 @@ class BtSyncHostAdd(BtBaseDialog):
 					))
 				else:
 					return response
+
+class BtSyncSettingsAdvanced(BtBaseDialog):
+	def __init__(self,agent):
+		BtBaseDialog.__init__(self, 'dialogs.glade', 'advsettings')
+		self.agent = agent
+		self.changed = False
+
+	def create(self):
+		BtBaseDialog.create(self)
+		self.username = self.agent.get_pref('username',None)
+		self.password = self.agent.get_pref('password',None)
+		self.bindui = self.agent.get_pref('bindui','127.0.0.1')
+		self.portui = self.agent.get_pref('portui',None)
+
+		self.username_w = self.builder.get_object('username_value')
+		self.password_w = self.builder.get_object('password_value')
+		self.bindportset_w = self.builder.get_object('bindport_set')
+		self.bindport_w = self.builder.get_object('bindport_value')
+		self.bindlocal_w = self.builder.get_object('bind_local')
+		self.bindall_w = self.builder.get_object('bind_all')
+		self.bindother_w = self.builder.get_object('bind_other')
+
+		self.bindportset_w.set_active(self.portui is not None)
+		self.bindport_w.set_sensitive(self.portui is not None)
+		self.bindport_w.set_range(8000, 65534)
+		self.bindport_w.set_increments(1, 100)
+		self.bindport_w.set_value(self.agent.uid + 8999 if self.portui is None else self.portui)
+		self.username_w.set_text("" if self.username is None else self.username)
+		self.password_w.set_text("" if self.password is None else self.password)
+
+		self.bindother_w.set_sensitive(False)
+		if self.bindui == '127.0.0.1':
+			self.bindlocal_w.set_active(True)
+		elif self.bindui == '0.0.0.0':
+			self.bindall_w.set_active(True)
+		else:
+			self.bindother_w.set_active(True)
+
+	def run(self):
+		self.dlg.set_default_response(Gtk.ResponseType.OK)
+		while True:
+			response = BtBaseDialog.run(self)
+			if response == Gtk.ResponseType.CANCEL:
+				return response
+			elif response == Gtk.ResponseType.DELETE_EVENT:
+				return response
+			elif response == Gtk.ResponseType.OK:
+				if self.changed:
+					self.username = self.username_w.get_text()
+					self.password = self.password_w.get_text()
+					if self.username == '' or self.password == '':
+						self.username = None
+						self.password = None
+					self.portui = self.bindport_w.get_value if self.bindportset_w.get_active() else None
+				return response
+
+	def onChanged(self,widget):
+		self.changed = True
+
+	def onBindPortToggled(self,widget):
+		self.bindport_w.set_sensitive(widget.get_active())
+		self.portui = self.bindport_w.get_value() if widget.get_active() else None
+		self.changed = True
+
+	def onBindLocalHost(self,widget):
+		if widget.get_active():
+			self.bindui = '127.0.0.1'
+			self.changed = True
+
+	def onBindAll(self,widget):
+		if widget.get_active():
+			self.bindui = '0.0.0.0'
+			self.changed = True
 
 class BtSyncPrefsAdvanced(BtBaseDialog,BtInputHelper):
 

--- a/btsync-gui/dialogs.py
+++ b/btsync-gui/dialogs.py
@@ -505,7 +505,7 @@ class BtSyncSettingsAdvanced(BtBaseDialog):
 		BtBaseDialog.create(self)
 		self.username = self.agent.get_pref('username',None)
 		self.password = self.agent.get_pref('password',None)
-		self.bindui = self.agent.get_pref('bindui','127.0.0.1')
+		self.bindui = self.agent.get_pref('bindui',None)
 		self.portui = self.agent.get_pref('portui',None)
 
 		self.username_w = self.builder.get_object('username_value')
@@ -525,12 +525,13 @@ class BtSyncSettingsAdvanced(BtBaseDialog):
 		self.password_w.set_text("" if self.password is None else self.password)
 
 		self.bindother_w.set_sensitive(False)
-		if self.bindui == '127.0.0.1':
+		if self.bindui is None or self.bindui == '127.0.0.1' or self.bindui == 'localhost':
 			self.bindlocal_w.set_active(True)
-		elif self.bindui == '0.0.0.0':
+		elif self.bindui == '0.0.0.0' or self.bindui == 'auto':
 			self.bindall_w.set_active(True)
 		else:
 			self.bindother_w.set_active(True)
+		self.changed = False
 
 	def run(self):
 		self.dlg.set_default_response(Gtk.ResponseType.OK)
@@ -542,12 +543,33 @@ class BtSyncSettingsAdvanced(BtBaseDialog):
 				return response
 			elif response == Gtk.ResponseType.OK:
 				if self.changed:
+					# read settings
 					self.username = self.username_w.get_text()
 					self.password = self.password_w.get_text()
 					if self.username == '' or self.password == '':
 						self.username = None
 						self.password = None
-					self.portui = self.bindport_w.get_value if self.bindportset_w.get_active() else None
+					self.portui = self.bindport_w.get_value_as_int() if self.bindportset_w.get_active() else None
+					if self.bindlocal_w.get_active():
+						self.bindui = None
+					elif self.bindall_w.get_active():
+						self.bindui = '0.0.0.0'
+					# process settings
+					self.agent.set_pref('username', self.username, delnone=True)
+					self.agent.set_pref('password', self.password, delnone=True)
+					self.agent.set_pref('bindui', self.bindui, delnone=True)
+					self.agent.set_pref('portui', self.portui, delnone=True)
+					# restart the whole game...
+					if self.agent.paused:
+						self.agent.load_prefs()
+						self.agent.read_prefs()
+						self.agent.reset_connection_params()
+					else:
+						self.agent.suspend()
+						self.agent.load_prefs()
+						self.agent.read_prefs()
+						self.agent.reset_connection_params()
+						self.agent.resume()
 				return response
 
 	def onChanged(self,widget):
@@ -555,18 +577,8 @@ class BtSyncSettingsAdvanced(BtBaseDialog):
 
 	def onBindPortToggled(self,widget):
 		self.bindport_w.set_sensitive(widget.get_active())
-		self.portui = self.bindport_w.get_value() if widget.get_active() else None
 		self.changed = True
 
-	def onBindLocalHost(self,widget):
-		if widget.get_active():
-			self.bindui = '127.0.0.1'
-			self.changed = True
-
-	def onBindAll(self,widget):
-		if widget.get_active():
-			self.bindui = '0.0.0.0'
-			self.changed = True
 
 class BtSyncPrefsAdvanced(BtBaseDialog,BtInputHelper):
 


### PR DESCRIPTION
This pull request implements a whole new way to manage the local configuration of the client. Previously everything was managed from the command line. Now the GUI has a separate tab with all local settings that can be changed interactively:

- switch between bright and dark icon set
- enable/disable web UI in menu
- enable/disable menu folders (like in btsync-user) - still not functional
- configure all advanced connection parameters:
  - username
  - password
  - Web UI bind address
  - Web UI bind port

It is still possible (but not recommended) to manage the settings also from command line.